### PR TITLE
Typos, Campaign Info Symbols, User Format Fix

### DIFF
--- a/cogs/campaign.py
+++ b/cogs/campaign.py
@@ -107,9 +107,9 @@ class Campaign(commands.Cog):
                 member_name = "Left the Server"
                 if member:
                     member_name = member.display_name
-                info_string += f"---Time: {timeConversion(player['Campaigns'][campaignRecords['Name']]['Time'])}\n"
-                info_string += f"---Sessions: {player['Campaigns'][campaignRecords['Name']]['Sessions']}\n"
-                info_string += f"---Active Member: {player['Campaigns'][campaignRecords['Name']]['Active']}"
+                info_string += f"• Time: {timeConversion(player['Campaigns'][campaignRecords['Name']]['Time'])}\n"
+                info_string += f"• Sessions: {player['Campaigns'][campaignRecords['Name']]['Sessions']}\n"
+                info_string += f"• Active Member: {player['Campaigns'][campaignRecords['Name']]['Active']}"
                 infoEmbed.add_field(name=f"**{member.display_name}**:", value = info_string, inline = False)
         infoEmbed.description = description_string
         
@@ -117,10 +117,10 @@ class Campaign(commands.Cog):
         member_name = "Left the Server"
         if member:
             member_name = member.display_name
-        master_text += f"---Time: {timeConversion(master['Campaigns'][campaignRecords['Name']]['Time'])}\n"
-        master_text += f"---Sessions: {master['Campaigns'][campaignRecords['Name']]['Sessions']}\n"
-        master_text += f"---Active Member: {master['Campaigns'][campaignRecords['Name']]['Active']}"
-        infoEmbed.insert_field_at(0, name=f"**Campaign Master {member_name}**:", value = master_text, inline = False)
+        master_text += f"• Time: {timeConversion(master['Campaigns'][campaignRecords['Name']]['Time'])}\n"
+        master_text += f"• Sessions: {master['Campaigns'][campaignRecords['Name']]['Sessions']}\n"
+        master_text += f"• Active Member: {master['Campaigns'][campaignRecords['Name']]['Active']}"
+        infoEmbed.insert_field_at(0, name=f"**{member_name}** (Campaign Master):", value = master_text, inline = False)
         await ctx.channel.send(embed=infoEmbed)
     
     #@commands.cooldown(1, 5, type=commands.BucketType.member)
@@ -300,7 +300,7 @@ class Campaign(commands.Cog):
             return
 
         if campaignRecords['Campaign Master ID'] != str(author.id):
-            await channel.send(f"You cannot remove users from this campaign because you are not the campaign master of {campaignRecords['Name']}")
+            await channel.send(f"You cannot remove users from this campaign because you are not the Campaign Master of {campaignRecords['Name']}")
             return
         try:
             usersCollection.update_one({'User ID': str(user[0].id)}, {"$set": {f"Campaigns.{campaignRecords['Name']}.Active": False}}, upsert=True)

--- a/cogs/char.py
+++ b/cogs/char.py
@@ -2513,10 +2513,10 @@ class Character(commands.Cog):
                     char_race = charDict['Race']
                     if "Reflavor" in charDict:
                         char_race = f"{charDict['Reflavor']} ({char_race})"
-                    charString += f"• **{charDict['Name']}**: Lv {charDict['Level']}, {char_race}, {charDict['Class']}"
+                    charString += f"• **{charDict['Name']}**: Lv {charDict['Level']}, {char_race}, {charDict['Class']}\n"
 
                     if 'Guild' in charDict:
-                        charString += f", *{charDict['Guild']}*\n"
+                        charString += f"---Guild: *{charDict['Guild']}*\n"
 
                     if len(charString) > (768 * pages):
                         pageStops.append(len(tempCharString))
@@ -2617,7 +2617,7 @@ class Character(commands.Cog):
             nick_string = ""
             if "Nickname" in charDict and charDict['Nickname'] != "":
                 nick_string = f"Goes By: **{charDict['Nickname']}**\n"
-            description = f"{nick_string}{char_race}\n{charDict['Class']}\n{charDict['Background']}\nGames Played: {charDict['Games']}\n"
+            description = f"{nick_string}{char_race}\n{charDict['Class']}\n{charDict['Background']}\nOne-shots Played: {charDict['Games']}\n"
             if 'Proficiency' in charDict:
                 description +=  f"Extra Training: {charDict['Proficiency']}\n"
             if 'NoodleTraining' in charDict:
@@ -2650,7 +2650,7 @@ class Character(commands.Cog):
 
             if 'Death' in charDict:
                 statusEmoji = "⚰️"
-                description += f"{statusEmoji} Status: **DEAD** -  decide their fate with {commandPrefix}death" 
+                description += f"{statusEmoji} Status: **DEAD** -  decide their fate with the following command: {commandPrefix}death" 
                 charEmbed.colour = discord.Colour(0xbb0a1e)
 
             charDictAuthor = guild.get_member(int(charDict['User ID']))
@@ -4028,7 +4028,7 @@ class Character(commands.Cog):
 
         
         if statRecords is None:
-            statsEmbed.add_field(name="Fanatic Stats", value="There have been 0 valid games played this month. Check back later!", inline=False)
+            statsEmbed.add_field(name="Fanatic Stats", value="There have been 0 valid one-shots played this month. Check back later!", inline=False)
         else:
             friend_list = []
             guild_list = []


### PR DESCRIPTION
- Fixed various typos.
- Changed symbols for "$campaign info" display.
- Reverted the "$user" format (added a line break which was previously removed, causing characters of the same tier to appear on one line instead of on their own line).