### PR TITLE
Typo Fixes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -360,7 +360,7 @@ async def help(ctx, *, pageString=''):
 
     helpEmbedGuild.add_field(name=f'▫️ Pinning a Message (Guildmaster only)', value=f'{commandPrefix}guild pin', inline=False)
 
-    helpEmbedGuild.add_field(name=f'▫️ Unpinning all Messages (Guildmaster only)', value=f'{commandPrefix}guild unpin', inline=False)
+    helpEmbedGuild.add_field(name=f'▫️ Unpinning a Message (Guildmaster only)', value=f'{commandPrefix}guild unpin', inline=False)
 
     helpEmbedGuild.add_field(name=f'▫️ Changing the Channel Topic (Guildmaster only)', value=f'{commandPrefix}guild topic text', inline=False)
 
@@ -410,7 +410,7 @@ async def help(ctx, *, pageString=''):
 
     helpEmbedGuild.add_field(name=f'▫️ Pinning a Message', value=f'{commandPrefix}campaign pin', inline=False)
 
-    helpEmbedGuild.add_field(name=f'▫️ Unpinning all Messages', value=f'{commandPrefix}campaign unpin', inline=False)
+    helpEmbedGuild.add_field(name=f'▫️ Unpinning a Message', value=f'{commandPrefix}campaign unpin', inline=False)
 
     helpEmbedGuild.add_field(name=f'▫️ Changing the Channel Topic', value=f'{commandPrefix}campaign topic text', inline=False)
 

--- a/cogs/char.py
+++ b/cogs/char.py
@@ -3156,7 +3156,7 @@ class Character(commands.Cog):
     
     @commands.cooldown(1, 5, type=commands.BucketType.member)
     @is_log_channel()
-    @commands.command(aliases=['r6'])
+    @commands.command(aliases=['rf'])
     async def reflavor(self,ctx, char, *, new_race):
         if( len(new_race) > 20 or len(new_race) <1):
             await ctx.channel.send(content=f'The new race must be between 1 and 20 symbols.')

--- a/cogs/guild.py
+++ b/cogs/guild.py
@@ -9,14 +9,14 @@ async def pin_control(self, ctx, goal):
         author = ctx.author
         channel = ctx.channel
         print(ctx.invoked_with)
-        infoMessage = await channel.send(f"React to the message you want to {ctx.invoked_with} with 📌")
+        infoMessage = await channel.send(f"You have 60 seconds to react to the message you want to {ctx.invoked_with} with the 📌 emoji (`:pushpin:`)!")
         def pinnedEmbedCheck(event):
             print(event)
             return str(event.emoji) == '📌' and event.user_id == author.id
         try:
             event = await self.bot.wait_for("raw_reaction_add", check=pinnedEmbedCheck , timeout=60)
         except asyncio.TimeoutError:
-            await infoMessage.edit(content=f'{ctx.invoked_with} timed out! Try again.')
+            await infoMessage.edit(content=f'The `{ctx.invoked_with}` command has timed out! Try again.')
             return
         message = await channel.fetch_message(event.message_id)
         await (getattr(message, goal))()


### PR DESCRIPTION
- Changed `r6` alias to `rf`.
- Changed `pin` and `unpin` commands in Help menus.
- Fixed `pin` and `unpin` wording.