### PR TITLE
Re-flavor Help Menu, TP Typos on Level-Up, Info Cleanup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -196,7 +196,7 @@ async def help(ctx, *, pageString=''):
 
     helpEmbedChar.add_field(name=f'▫️ Respecing a Character into a Multiclass', value=f'{commandPrefix}respec "character name" "new character name" "race" "class1 level / class2 level / class3 level / class4 level" "background" STR DEX CON INT WIS CHA', inline=False)
 
-    helpEmbedChar.add_field(name=f'▫️ Reflavoring a Character\'s Race', value=f'{commandPrefix}reflavor "character name" race name\n[{commandPrefix}rf]', inline=False)
+    helpEmbedChar.add_field(name=f'▫️ Reflavoring a Character', value=f'{commandPrefix}reflavor race "character name" race name\n{commandPrefix}reflavor class "character name" class name\n{commandPrefix}reflavor background "character name" background name\n[{commandPrefix}rf]', inline=False)
 
     helpEmbedChar.add_field(name=f'▫️ Adding Extra Names', value=f'{commandPrefix}alias "character name" "surname, nickname1, nickname2, othername, [...]\n[{commandPrefix}aka]', inline=False)
 

--- a/cogs/char.py
+++ b/cogs/char.py
@@ -2974,11 +2974,11 @@ class Character(commands.Cog):
             if "Alignment" in charDict and charDict['Alignment'] != "":
                 alignment_string = f"Alignment: {charDict['Alignment']}\n"
                 
-            description = f"{nick_string}{char_race}\n{charDict['Class']}\n{charDict['Background']}\n{alignment_string}One-shots Played: {charDict['Games']}\n"
+            description = f"• {nick_string}{char_race}\n• {charDict['Class']}\n• {charDict['Background']}\n• {alignment_string}• One-shots Played: {charDict['Games']}\n"
             if 'Proficiency' in charDict:
-                description +=  f"Extra Training: {charDict['Proficiency']}\n"
+                description +=  f"• Extra Training: {charDict['Proficiency']}\n"
             if 'NoodleTraining' in charDict:
-                description +=  f"Noodle Training: {charDict['NoodleTraining']}\n"
+                description +=  f"• Noodle Training: {charDict['NoodleTraining']}\n"
             description += f":moneybag: {charDict['GP']} GP\n"
             charLevel = charDict['Level']
             if charLevel < 5:
@@ -3018,8 +3018,8 @@ class Character(commands.Cog):
             tpString = ""
             for i in range (1,6):
                 if f"T{i} TP" in charDict:
-                    tpString += f"**Tier {i} TP**: {charDict[f'T{i} TP']} \n" 
-            charEmbed.add_field(name='TP', value=f"Current TP Item: **{charDict['Current Item']}**\n{tpString}", inline=True)
+                    tpString += f"• Tier {i} TP: {charDict[f'T{i} TP']} \n" 
+            charEmbed.add_field(name='TP', value=f"Current TP Item: {charDict['Current Item']}\n{tpString}", inline=True)
             if 'Guild' in charDict:
                 charEmbed.add_field(name='Guild', value=f"{charDict['Guild']}: Rank {charDict['Guild Rank']}", inline=True)
             charEmbed.add_field(name='Feats', value=charDict['Feats'], inline=False)
@@ -3126,7 +3126,7 @@ class Character(commands.Cog):
 
             charDict['HP'] += totalHPAdd * charLevel
 
-            charEmbed.add_field(name='Stats', value=f":heart: {charDict['HP']} Max HP\n**STR**: {charDict['STR']} \n**DEX**: {charDict['DEX']} \n**CON**: {charDict['CON']} \n**INT**: {charDict['INT']} \n**WIS**: {charDict['WIS']} \n**CHA**: {charDict['CHA']}", inline=False)
+            charEmbed.add_field(name='Stats', value=f":heart: {charDict['HP']} Max HP\n• STR: {charDict['STR']} \n• DEX: {charDict['DEX']} \n• CON: {charDict['CON']} \n• INT: {charDict['INT']} \n• WIS: {charDict['WIS']} \n• CHA: {charDict['CHA']}", inline=False)
             
             charEmbed.set_footer(text=footer)
 
@@ -3749,7 +3749,7 @@ class Character(commands.Cog):
 
                 roleName = await self.levelCheck(ctx, newCharLevel, charName)
                 levelUpEmbed.clear_fields()
-                await levelUpEmbedmsg.edit(content=f":arrow_up:   __**L E V E L   U P!**__\n\n:warning:   **Don't forget to spend your TP!** Use the following command to spend your TP:\n```yaml\n$tp buy \"{charName}\" \"magic item\"```", embed=levelUpEmbed)
+                await levelUpEmbedmsg.edit(content=f":arrow_up:   __**L E V E L   U P!**__\n\n:warning:   **Don't forget to spend your TP!** Use one of the following commands to do so:\n```yaml\n$tp find \"{charName}\" \"magic item\"\n$tp craft \"{charName}\" \"magic item\"\n$tp meme \"{charName}\" \"magic item\"```", embed=levelUpEmbed)
                 
                 if roleName != "":
                     levelUpEmbed.title = f":tada: {roleName} role acquired! :tada:\n" + levelUpEmbed.title


### PR DESCRIPTION
- Changed re-flavor command on the help menu.
- Changed `tp buy` to new versions when you level up.
- Cleaned up `info` slightly.